### PR TITLE
Added capability to use CocoaPods

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,8 @@ If you have pro-guard enabled and are having trouble with your build, apply this
 ```
 
 ## iOS
+
+### Option: Manually
 In Xcode, drag both `RCTCustomInputController.xcodeproj` and `KeyboardTrackingView.xcodeproj` from your `node_modules` to the Libraries folder in the Project Navigator, then add `libRCTCustomInputController.a` and `libKeyboardTrackingView.a` to your app target "Linked Frameworks and Libraries".
 
 #### Covering the whold keyboard in predictive mode
@@ -64,6 +66,15 @@ From Xcode menu:
  3. Drag and position `KeyboardTrackingView` to be first, above your project, and unmark "Parallelize Build" option at the top.
 
 If necessary, you can take a look at how it is set-up in the demo project.
+
+### Option: With [CocoaPods](https://cocoapods.org/)
+
+Add the following two pods to your `Podfile` and run `pod update`:
+
+```
+pod 'react-native-keyboard-input', :path => '../node_modules/react-native-keyboard-input'
+pod 'react-native-keyboard-tracking-view', :path => '../node_modules/react-native-keyboard-tracking-view'
+```
 
 
 # Usage

--- a/react-native-keyboard-input.podspec
+++ b/react-native-keyboard-input.podspec
@@ -1,0 +1,18 @@
+require 'json'
+version = JSON.parse(File.read('package.json'))["version"]
+
+Pod::Spec.new do |s|
+
+  s.name                  = "react-native-keyboard-input"
+  s.version               = version
+  s.summary               = "Keyboard Input for React Native."
+  s.homepage              = "https://github.com/wix/react-native-keyboard-input"
+  s.license               = 'MIT'
+  s.source                = { path: '.' }
+  s.ios.deployment_target = '9.0'
+  s.authors               = { 'Leo Natan' => 'lnatan@wix.com' }
+  s.source_files          = 'lib/ios/{LNInterpolation/*,RCTCustomInputController/*}.{h,m,mm}'
+  s.dependency 'React'
+  s.dependency 'react-native-keyboard-tracking-view'
+
+end


### PR DESCRIPTION
Adding a podspec allows the user to include this library using
```
pod 'react-native-keyboard-input', :path => '../node_modules/react-native-keyboard-input'
pod 'react-native-keyboard-tracking-view', :path => '../node_modules/react-native-keyboard-tracking-view'
```
rather than adding libraries manually.

Dependent on https://github.com/wix/react-native-keyboard-tracking-view/pull/13 since we need that library to include a podspec