### PR TITLE
Use native iOS keyboard color

### DIFF
--- a/lib/ios/RCTCustomInputController/RCTCustomKeyboardViewController.m
+++ b/lib/ios/RCTCustomInputController/RCTCustomKeyboardViewController.m
@@ -60,6 +60,7 @@
     }
     
     _rootView = rootView;
+    _rootView.backgroundColor = nil; // Let iOS's natural keyboard color pass throught
     _rootView.translatesAutoresizingMaskIntoConstraints = NO;
     [self.inputView addSubview:_rootView];
     


### PR DESCRIPTION
RCTRootView always sets white as the backgroundcolor, which is a problem if we want to make a keyboard that looks and feels like the native iOS keyboard, like so:

![simulator screen shot - iphone x - 2018-06-18 at 12 02 50](https://user-images.githubusercontent.com/183747/41530212-c945e3d4-72ef-11e8-9dae-24db240a9252.png)

What we need for that is to have `UIInputView` as the background. Note that we can't just use a `<View>` with a solid background color, because UIInputView has a slight blur effect. We also can't pretend that a solid color is "close enough", because on iPhone X there's a little chin that has the native effect. Adding UIInputView inside the RCTRootView hierarchy also doesn't work AFAICT.

So the only solution I found is to simply remove RCTRootView's color when inserting it into RCTCustomKeyboardViewController hierarchy and it works fine.