### PR TITLE
Remove Lodash dependency

### DIFF
--- a/src/KeyboardsRegistry.js
+++ b/src/KeyboardsRegistry.js
@@ -1,6 +1,6 @@
 import {AppRegistry} from 'react-native';
-import _ from 'lodash';
 import EventEmitterManager from './utils/EventEmitterManager';
+import {intersection} from './utils/utils';
 
 /*
 * Tech debt: how to deal with multiple registries in the app?
@@ -20,7 +20,7 @@ export default class KeyboardRegistry {
   static eventEmitter = new EventEmitterManager();
 
   static registerKeyboard = (componentID, generator, params = {}) => {
-    if (!_.isFunction(generator)) {
+    if (typeof generator !== 'function') {
       console.error(`KeyboardRegistry.registerKeyboard: ${componentID} you must register a generator function`);//eslint-disable-line
       return;
     }
@@ -38,7 +38,7 @@ export default class KeyboardRegistry {
   };
 
   static getKeyboards = (componentIDs = []) => {
-    const validKeyboardIDs = _.intersection(componentIDs, Object.keys(KeyboardRegistry.registeredKeyboards));
+    const validKeyboardIDs = intersection(componentIDs, Object.keys(KeyboardRegistry.registeredKeyboards));
     return getKeyboardsWithIDs(validKeyboardIDs);
   };
 

--- a/src/utils/EventEmitterManager.js
+++ b/src/utils/EventEmitterManager.js
@@ -1,5 +1,3 @@
-import _ from 'lodash';
-
 export default class EventEmitterManager {
   constructor() {
     this.handlerCallbacks = {};
@@ -9,7 +7,7 @@ export default class EventEmitterManager {
     if (!this.handlerCallbacks[eventName]) {
       this.handlerCallbacks[eventName] = [];
     }
-    if (_.indexOf(this.handlerCallbacks[eventName], handlerCallback) === -1) {
+    if (this.handlerCallbacks[eventName].indexOf(handlerCallback) === -1) {
       this.handlerCallbacks[eventName].push(handlerCallback);
     }
   }

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -1,0 +1,3 @@
+export function intersection(first, second) {
+  return first.filter(element => second.indexOf(element) > -1);
+}


### PR DESCRIPTION
Lodash is a big dependency, used here in three very trivial places, and Metro bundler isn't very good at tree shaking. I replaced uses of it with simple vanilla JS. Seems to work perfectly fine and shaved over 100KB off my app's build size