### PR TITLE
Read build.gradle vars from host project

### DIFF
--- a/lib/android/build.gradle
+++ b/lib/android/build.gradle
@@ -1,12 +1,20 @@
+def getExtOrDefault(name) {
+  return rootProject.ext.has(name) ? rootProject.ext.get(name) : project.properties['ReactNativeKeyboardInput_' + name]
+}
+
+def getExtOrIntegerDefault(name) {
+  return rootProject.ext.has(name) ? rootProject.ext.get(name) : (project.properties['ReactNativeKeyboardInput_' + name]).toInteger()
+}
+
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 23
-    buildToolsVersion "25"
+    compileSdkVersion getExtOrIntegerDefault('compileSdkVersion')
+    buildToolsVersion getExtOrDefault('buildToolsVersion')
 
     defaultConfig {
-        minSdkVersion 16
-        targetSdkVersion 25
+        minSdkVersion getExtOrIntegerDefault('minSdkVersion')
+        targetSdkVersion getExtOrIntegerDefault('targetSdkVersion')
         versionCode 1
         versionName "1.0"
     }

--- a/lib/android/gradle.properties
+++ b/lib/android/gradle.properties
@@ -1,0 +1,4 @@
+ReactNativeKeyboardInput_compileSdkVersion=23
+ReactNativeKeyboardInput_buildToolsVersion=25
+ReactNativeKeyboardInput_targetSdkVersion=25
+ReactNativeKeyboardInput_minSdkVersion=16


### PR DESCRIPTION
Smooths over build problems that arise from different android tools versions between the host project and this library. This probably fixes #77.