### PR TITLE
Bump version react-native-keyboard-tracking-view

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   },
   "dependencies": {
     "lodash": "^4.17.4",
-    "react-native-keyboard-tracking-view": "^5.5.0"
+    "react-native-keyboard-tracking-view": "^5.7.0"
   },
   "peerDependencies": {
     "react": "16.9.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-native-keyboard-input",
   "description": "React Native Custom Input Controller",
-  "version": "6.0.0",
+  "version": "6.0.1",
   "main": "src/index.js",
   "publishConfig": {
     "registry": "https://registry.npmjs.org/"


### PR DESCRIPTION
Bump version to update version of react-native-keyboard-tracking-view : https://github.com/wix/react-native-keyboard-tracking-view/commit/fe3f48ac0dfacee5150565e722d8e03bd7c26de8

This version needs to be updated because of new iOS restriction on the UIWebView usage. 